### PR TITLE
修正在 BatchWriteRow 操作单行出错时的访问空指针错误

### DIFF
--- a/tablestore/api.go
+++ b/tablestore/api.go
@@ -627,10 +627,11 @@ func (tableStoreClient *TableStoreClient) BatchWriteRow(request *BatchWriteRowRe
 		for _, row := range (table.Rows) {
 			rowResult := &RowResult{TableName: *table.TableName, IsSucceed: *row.IsOk, ConsumedCapacityUnit : &ConsumedCapacityUnit{}, Index: index}
 			index++
-			rowResult.ConsumedCapacityUnit.Read = *row.Consumed.CapacityUnit.Read
-			rowResult.ConsumedCapacityUnit.Write = *row.Consumed.CapacityUnit.Write
 			if *row.IsOk == false {
 				rowResult.Error = Error{Code: *row.Error.Code, Message: *row.Error.Message }
+			} else {
+				rowResult.ConsumedCapacityUnit.Read = *row.Consumed.CapacityUnit.Read
+				rowResult.ConsumedCapacityUnit.Write = *row.Consumed.CapacityUnit.Write
 			} /*else {
 				rows, err := readRowsWithHeader(bytes.NewReader(row.Row))
 				if err != nil {


### PR DESCRIPTION
在 BatchWriteRow 中，单行出错时会访问 api.go 的 630 行 *row.Consumed.CapacityUnit.Read，而此时 *row.Consumed 为 nil，触发空指针错误。