### PR TITLE
AddPrimaryKeyColumnWith* 函数添加Value参数

### DIFF
--- a/sample/MultipleRowOperation.go
+++ b/sample/MultipleRowOperation.go
@@ -63,7 +63,7 @@ func BatchGetRowSample(client *tablestore.TableStoreClient, tableName string) {
 	if err != nil {
 		fmt.Println("batachget failed with error:", err)
 	} else {
-		for _, row := range (batchGetResponse.TableToRowsResult[mqCriteria.TableName]) {
+		for _, row := range batchGetResponse.TableToRowsResult[mqCriteria.TableName] {
 			if row.PrimaryKey.PrimaryKeys != nil {
 				fmt.Println("get row with key", row.PrimaryKey.PrimaryKeys[0].Value, row.PrimaryKey.PrimaryKeys[1].Value, row.PrimaryKey.PrimaryKeys[2].Value)
 			} else {
@@ -81,14 +81,15 @@ func GetRangeSample(client *tablestore.TableStoreClient, tableName string) {
 	rangeRowQueryCriteria := &tablestore.RangeRowQueryCriteria{}
 	rangeRowQueryCriteria.TableName = tableName
 
+	// 查询区间：[(1, INF_MIN), (4, INF_MAX))，左闭右开。
 	startPK := new(tablestore.PrimaryKey)
-	startPK.AddPrimaryKeyColumnWithMinValue("pk1")
-	startPK.AddPrimaryKeyColumnWithMinValue("pk2")
-	startPK.AddPrimaryKeyColumnWithMinValue("pk3")
+	startPK.AddPrimaryKeyColumnWithMinValue("pk1",int64(1))
+	startPK.AddPrimaryKeyColumnWithMinValue("pk2",int64(1))
+	startPK.AddPrimaryKeyColumnWithMinValue("pk3",int64(1))
 	endPK := new(tablestore.PrimaryKey)
-	endPK.AddPrimaryKeyColumnWithMaxValue("pk1")
-	endPK.AddPrimaryKeyColumnWithMaxValue("pk2")
-	endPK.AddPrimaryKeyColumnWithMaxValue("pk3")
+	endPK.AddPrimaryKeyColumnWithMaxValue("pk1",int64(4))
+	endPK.AddPrimaryKeyColumnWithMaxValue("pk2",int64(4))
+	endPK.AddPrimaryKeyColumnWithMaxValue("pk3",int64(4))
 	rangeRowQueryCriteria.StartPrimaryKey = startPK
 	rangeRowQueryCriteria.EndPrimaryKey = endPK
 	rangeRowQueryCriteria.Direction = tablestore.FORWARD
@@ -104,7 +105,7 @@ func GetRangeSample(client *tablestore.TableStoreClient, tableName string) {
 		if err != nil {
 			fmt.Println("get range failed with error:", err)
 		}
-		if (len(getRangeResp.Rows) > 0) {
+		if len(getRangeResp.Rows) > 0 {
 			for _, row := range getRangeResp.Rows {
 				fmt.Println("range get row with key", row.PrimaryKey.PrimaryKeys[0].Value, row.PrimaryKey.PrimaryKeys[1].Value, row.PrimaryKey.PrimaryKeys[2].Value)
 			}

--- a/sample/TableOperation.go
+++ b/sample/TableOperation.go
@@ -25,7 +25,7 @@ func CreateTableSample(client *tablestore.TableStoreClient, tableName string) {
 	createtableRequest.ReservedThroughput = reservedThroughput
 
 	_, err := client.CreateTable(createtableRequest)
-	if (err != nil) {
+	if err != nil {
 		fmt.Println("Failed to create table with error:", err)
 	} else {
 		fmt.Println("Create table finished")
@@ -62,7 +62,7 @@ func DeleteTableSample(client *tablestore.TableStoreClient) {
 	deleteReq := new(tablestore.DeleteTableRequest)
 	deleteReq.TableName = tableName
 	_, err := client.DeleteTable(deleteReq)
-	if (err != nil) {
+	if err != nil {
 		fmt.Println("Failed to delete table with error:", err)
 	} else {
 		fmt.Println("Delete table finished")
@@ -76,7 +76,7 @@ func ListTableSample(client *tablestore.TableStoreClient) {
 		fmt.Println("Failed to list table")
 	} else {
 		fmt.Println("List table result is")
-		for _, table := range (listtables.TableNames) {
+		for _, table := range listtables.TableNames {
 			fmt.Println("TableName: ", table)
 		}
 	}
@@ -92,7 +92,7 @@ func UpdateTableSample(client *tablestore.TableStoreClient, tableName string) {
 
 	_, err := client.UpdateTable(updateTableReq)
 
-	if (err != nil) {
+	if err != nil {
 		fmt.Println("failed to update table with error:", err)
 	} else {
 		fmt.Println("update finished")

--- a/tablestore/util.go
+++ b/tablestore/util.go
@@ -639,17 +639,17 @@ func (pk *PrimaryKey) AddPrimaryKeyColumn(primaryKeyName string, value interface
 	pk.PrimaryKeys = append(pk.PrimaryKeys, buildPrimaryKey(primaryKeyName, value))
 }
 
-func (pk *PrimaryKey) AddPrimaryKeyColumnWithAutoIncrement(primaryKeyName string) {
-	pk.PrimaryKeys = append(pk.PrimaryKeys, &PrimaryKeyColumn{ColumnName: primaryKeyName, PrimaryKeyOption: AUTO_INCREMENT })
+func (pk *PrimaryKey) AddPrimaryKeyColumnWithAutoIncrement(primaryKeyName string,value interface{}) {
+	pk.PrimaryKeys = append(pk.PrimaryKeys, &PrimaryKeyColumn{ColumnName: primaryKeyName, Value:value, PrimaryKeyOption: AUTO_INCREMENT })
 }
 
-func (pk *PrimaryKey) AddPrimaryKeyColumnWithMinValue(primaryKeyName string) {
-	pk.PrimaryKeys = append(pk.PrimaryKeys, &PrimaryKeyColumn{ColumnName: primaryKeyName, PrimaryKeyOption: MIN })
+func (pk *PrimaryKey) AddPrimaryKeyColumnWithMinValue(primaryKeyName string, value interface{}) {
+	pk.PrimaryKeys = append(pk.PrimaryKeys, &PrimaryKeyColumn{ColumnName: primaryKeyName, Value: value, PrimaryKeyOption: MIN })
 }
 
 // Only used for range query
-func (pk *PrimaryKey) AddPrimaryKeyColumnWithMaxValue(primaryKeyName string) {
-	pk.PrimaryKeys = append(pk.PrimaryKeys, &PrimaryKeyColumn{ColumnName: primaryKeyName, PrimaryKeyOption: MAX })
+func (pk *PrimaryKey) AddPrimaryKeyColumnWithMaxValue(primaryKeyName string, value interface{}) {
+	pk.PrimaryKeys = append(pk.PrimaryKeys, &PrimaryKeyColumn{ColumnName: primaryKeyName, Value:value, PrimaryKeyOption: MAX })
 }
 
 func (rowchange *PutRowChange) SetCondition(rowExistenceExpectation RowExistenceExpectation) {


### PR DESCRIPTION
参考py的sdk, getRange相关函数'AddPrimaryKeyColumnWith'，应该带上参数value
https://github.com/aliyun/aliyun-tablestore-python-sdk/blob/master/examples/get_range.py