### PR TITLE
add Limit parameter in toRangeCriteria

### DIFF
--- a/timeline/store.go
+++ b/timeline/store.go
@@ -164,6 +164,7 @@ func toRangeCriteria(id string, param *ScanParameter, opt *StoreOption) *tablest
 		ColumnsToGet:    param.ColToGet,
 		Filter:          param.Filter,
 		Direction:       tablestore.FORWARD,
+		Limit:           int32(param.MaxCount),
 	}
 	if param.IsForward == false {
 		criteria.Direction = tablestore.BACKWARD


### PR DESCRIPTION
timeline 下面DefaultStore的Scan实现中，MaxCount参数没生效，原因是toRangeCriteria的实现中，Limit参数没传。