### PR TITLE
changed searchQuery name to be exported

### DIFF
--- a/tablestore/search/scan_query.go
+++ b/tablestore/search/scan_query.go
@@ -9,7 +9,7 @@ type ScanQuery interface {
 	Serialize() ([]byte, error)
 }
 
-type scanQuery struct {
+type ScanQueryBase struct {
 	Query		Query
 	Limit		*int32
 	AliveTime	*int32	//in seconds, 60s by default
@@ -18,41 +18,41 @@ type scanQuery struct {
 	MaxParallel			*int32
 }
 
-func NewScanQuery() *scanQuery {
-	return &scanQuery{}
+func NewScanQuery() *ScanQueryBase {
+	return &ScanQueryBase{}
 }
 
-func (s *scanQuery) SetQuery(query Query)  *scanQuery {
+func (s *ScanQueryBase) SetQuery(query Query)  *ScanQueryBase {
 	s.Query = query
 	return s
 }
 
-func (s *scanQuery) SetLimit(limit int32) *scanQuery {
+func (s *ScanQueryBase) SetLimit(limit int32) *ScanQueryBase {
 	s.Limit = proto.Int32(limit)
 	return s
 }
 
-func (s *scanQuery) SetAliveTime(aliveTime int32) *scanQuery {
+func (s *ScanQueryBase) SetAliveTime(aliveTime int32) *ScanQueryBase {
 	s.AliveTime = proto.Int32(aliveTime)
 	return s
 }
 
-func (s *scanQuery) SetToken(token []byte) *scanQuery {
+func (s *ScanQueryBase) SetToken(token []byte) *ScanQueryBase {
 	s.Token = token
 	return s
 }
 
-func (s *scanQuery) SetCurrentParallelID(currentParallelID int32) *scanQuery {
+func (s *ScanQueryBase) SetCurrentParallelID(currentParallelID int32) *ScanQueryBase {
 	s.CurrentParallelID = proto.Int32(currentParallelID)
 	return s
 }
 
-func (s *scanQuery) SetMaxParallel(maxParallel int32) *scanQuery {
+func (s *ScanQueryBase) SetMaxParallel(maxParallel int32) *ScanQueryBase {
 	s.MaxParallel = proto.Int32(maxParallel)
 	return s
 }
 
-func (s *scanQuery) Serialize() ([]byte, error) {
+func (s *ScanQueryBase) Serialize() ([]byte, error) {
 	scanQuery := &otsprotocol.ScanQuery{}
 
 	if s.Query != nil {

--- a/tablestore/search/scan_query_test.go
+++ b/tablestore/search/scan_query_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSerialize(t *testing.T) {
-	scanQuery := scanQuery{
+	scanQuery := ScanQueryBase{
 		Query:             &MatchQuery{
 			FieldName:          "field1",
 			Text:               "value1",
@@ -46,7 +46,7 @@ func TestSerialize(t *testing.T) {
 
 func TestSerializeLimit(t *testing.T) {
 	{	//nil
-		scanQuery := scanQuery{}
+		scanQuery := ScanQueryBase{}
 		scanQueryBytes, _ := scanQuery.Serialize()
 
 		scanQuery2 := &otsprotocol.ScanQuery{}
@@ -55,7 +55,7 @@ func TestSerializeLimit(t *testing.T) {
 		assert.Nil(t, scanQuery2.Limit)
 	}
 	{	//<0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			Limit: proto.Int32(-1),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -66,7 +66,7 @@ func TestSerializeLimit(t *testing.T) {
 		assert.Nil(t, scanQuery2.Limit)
 	}
 	{	//>=0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			Limit: proto.Int32(0),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -80,7 +80,7 @@ func TestSerializeLimit(t *testing.T) {
 
 func TestSerializeAliveTime(t *testing.T) {
 	{	//nil
-		scanQuery := scanQuery{}
+		scanQuery := ScanQueryBase{}
 		scanQueryBytes, _ := scanQuery.Serialize()
 
 		scanQuery2 := &otsprotocol.ScanQuery{}
@@ -89,7 +89,7 @@ func TestSerializeAliveTime(t *testing.T) {
 		assert.Nil(t, scanQuery2.AliveTime)
 	}
 	{	//<=0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			AliveTime: proto.Int32(0),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -100,7 +100,7 @@ func TestSerializeAliveTime(t *testing.T) {
 		assert.Nil(t, scanQuery2.AliveTime)
 	}
 	{	//>0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			AliveTime: proto.Int32(1),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -114,7 +114,7 @@ func TestSerializeAliveTime(t *testing.T) {
 
 func TestSerializeToken(t *testing.T) {
 	{	//token == nil
-		scanQuery := scanQuery{}
+		scanQuery := ScanQueryBase{}
 		scanQueryBytes, _ := scanQuery.Serialize()
 
 		scanQuery2 := &otsprotocol.ScanQuery{}
@@ -123,7 +123,7 @@ func TestSerializeToken(t *testing.T) {
 		assert.Nil(t, scanQuery2.Token)
 	}
 	{	//len(token) > 0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			Token: []byte("xyz"),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -137,7 +137,7 @@ func TestSerializeToken(t *testing.T) {
 
 func TestSerializeCurrentParallelID(t *testing.T) {
 	{	//nil
-		scanQuery := scanQuery{}
+		scanQuery := ScanQueryBase{}
 		scanQueryBytes, _ := scanQuery.Serialize()
 
 		scanQuery2 := &otsprotocol.ScanQuery{}
@@ -146,7 +146,7 @@ func TestSerializeCurrentParallelID(t *testing.T) {
 		assert.Nil(t, scanQuery2.CurrentParallelId)
 	}
 	{	//<0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			CurrentParallelID: proto.Int32(-1),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -157,7 +157,7 @@ func TestSerializeCurrentParallelID(t *testing.T) {
 		assert.Nil(t, scanQuery2.CurrentParallelId)
 	}
 	{	//>=0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			CurrentParallelID: proto.Int32(0),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -171,7 +171,7 @@ func TestSerializeCurrentParallelID(t *testing.T) {
 
 func TestSerializeMaxParallel(t *testing.T) {
 	{	//nil
-		scanQuery := scanQuery{}
+		scanQuery := ScanQueryBase{}
 		scanQueryBytes, _ := scanQuery.Serialize()
 
 		scanQuery2 := &otsprotocol.ScanQuery{}
@@ -180,7 +180,7 @@ func TestSerializeMaxParallel(t *testing.T) {
 		assert.Nil(t, scanQuery2.MaxParallel)
 	}
 	{	//<=0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			MaxParallel: proto.Int32(0),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()
@@ -192,7 +192,7 @@ func TestSerializeMaxParallel(t *testing.T) {
 	}
 
 	{	//>0
-		scanQuery := scanQuery{
+		scanQuery := ScanQueryBase{
 			MaxParallel: proto.Int32(1),
 		}
 		scanQueryBytes, _ := scanQuery.Serialize()

--- a/tablestore/search/search_query.go
+++ b/tablestore/search/search_query.go
@@ -9,7 +9,7 @@ type SearchQuery interface {
 	Serialize() ([]byte, error)
 }
 
-type SearchQueryObject struct {
+type SearchQueryBase struct {
 	Offset        int32
 	Limit         int32
 	Query         Query
@@ -21,25 +21,25 @@ type SearchQueryObject struct {
 	GroupBys      []GroupBy
 }
 
-func NewSearchQuery() *SearchQueryObject {
-	return &SearchQueryObject{
+func NewSearchQuery() *SearchQueryBase {
+	return &SearchQueryBase{
 		Offset:        -1,
 		Limit:         -1,
 		GetTotalCount: false,
 	}
 }
 
-func (s *SearchQueryObject) SetOffset(offset int32) *SearchQueryObject {
+func (s *SearchQueryBase) SetOffset(offset int32) *SearchQueryBase {
 	s.Offset = offset
 	return s
 }
 
-func (s *SearchQueryObject) SetLimit(limit int32) *SearchQueryObject {
+func (s *SearchQueryBase) SetLimit(limit int32) *SearchQueryBase {
 	s.Limit = limit
 	return s
 }
 
-func (s *SearchQueryObject) SetQuery(query Query) *SearchQueryObject {
+func (s *SearchQueryBase) SetQuery(query Query) *SearchQueryBase {
 	s.Query = query
 	return s
 }
@@ -115,42 +115,42 @@ func NewGroupByGeoDistance(name string, fieldName string, origin GeoPoint) *Grou
 	}
 }
 
-func (s *SearchQueryObject) Aggregation(agg ...Aggregation) *SearchQueryObject {
+func (s *SearchQueryBase) Aggregation(agg ...Aggregation) *SearchQueryBase {
 	for i := 0; i < len(agg); i++ {
 		s.Aggregations = append(s.Aggregations, agg[i])
 	}
 	return s
 }
 
-func (s *SearchQueryObject) GroupBy(groupBy ...GroupBy) *SearchQueryObject {
+func (s *SearchQueryBase) GroupBy(groupBy ...GroupBy) *SearchQueryBase {
 	for i := 0; i < len(groupBy); i++ {
 		s.GroupBys = append(s.GroupBys, groupBy[i])
 	}
 	return s
 }
 
-func (s *SearchQueryObject) SetCollapse(collapse *Collapse) *SearchQueryObject {
+func (s *SearchQueryBase) SetCollapse(collapse *Collapse) *SearchQueryBase {
 	s.Collapse = collapse
 	return s
 }
 
-func (s *SearchQueryObject) SetSort(sort *Sort) *SearchQueryObject {
+func (s *SearchQueryBase) SetSort(sort *Sort) *SearchQueryBase {
 	s.Sort = sort
 	return s
 }
 
-func (s *SearchQueryObject) SetGetTotalCount(getTotalCount bool) *SearchQueryObject {
+func (s *SearchQueryBase) SetGetTotalCount(getTotalCount bool) *SearchQueryBase {
 	s.GetTotalCount = getTotalCount
 	return s
 }
 
-func (s *SearchQueryObject) SetToken(token []byte) *SearchQueryObject {
+func (s *SearchQueryBase) SetToken(token []byte) *SearchQueryBase {
 	s.Token = token
 	s.Sort = nil
 	return s
 }
 
-func (s *SearchQueryObject) Serialize() ([]byte, error) {
+func (s *SearchQueryBase) Serialize() ([]byte, error) {
 	searchQuery := &otsprotocol.SearchQuery{}
 	if s.Offset >= 0 {
 		searchQuery.Offset = &s.Offset


### PR DESCRIPTION
Will help in breaking a single function of building the query and the request and pagination to multiple functions,
so this type can be used as an argument type or function return type.